### PR TITLE
login.lua update to display XP Gain Rate correctly

### DIFF
--- a/data/creaturescripts/scripts/others/login.lua
+++ b/data/creaturescripts/scripts/others/login.lua
@@ -194,21 +194,21 @@ function onLogin(player)
         onMovementRemoveProtection(playerId, player:getPosition(), 10)
 	end
 
-	-- Exp stats
+	-- Set Client XP Gain Rate
 	local staminaMinutes = player:getStamina()
-	local Boost = player:getExpBoostStamina()
-	if staminaMinutes > 2400 and player:isPremium() and Boost > 0 then
-		player:setBaseXpGain(Game.getExperienceStage(player:getLevel())*2) -- 200 = 1.0x, 200 = 2.0x, ... premium account
-	elseif staminaMinutes > 2400 and player:isPremium() and Boost <= 0 then
-		player:setBaseXpGain(Game.getExperienceStage(player:getLevel())*1.5) -- 150 = 1.0x, 150 = 1.5x, ... premium account
-	elseif staminaMinutes <= 2400 and staminaMinutes > 840 and player:isPremium() and Boost > 0 then
-		player:setBaseXpGain(Game.getExperienceStage(player:getLevel())*1.5) -- 150 = 1.5x		premium account
+	local storeBoost = player:getExpBoostStamina()
+	if staminaMinutes > 2400 and player:isPremium() and storeBoost > 0 then
+		player:setBaseXpGain(Game.getExperienceStage(player:getLevel())*2*100) -- Premium + Stamina boost + Store boost
+	elseif staminaMinutes > 2400 and player:isPremium() and storeBoost <= 0 then
+		player:setBaseXpGain(Game.getExperienceStage(player:getLevel())*1.5*100) -- Premium + Stamina boost
+	elseif staminaMinutes <= 2400 and staminaMinutes > 840 and player:isPremium() and storeBoost > 0 then
+		player:setBaseXpGain(Game.getExperienceStage(player:getLevel())*1.5*100) -- Premium + Store boost
 	elseif staminaMinutes > 840 and Boost > 0 then
-		player:setBaseXpGain(Game.getExperienceStage(player:getLevel())*1.5) -- 150 = 1.5x		free account
+		player:setBaseXpGain(Game.getExperienceStage(player:getLevel())*1.5*100) -- FACC + Store boost
 	elseif staminaMinutes <= 840 and Boost > 0 then
-		player:setBaseXpGain(Game.getExperienceStage(player:getLevel())*1) -- 50 = 0.5x	all players
+		player:setBaseXpGain(Game.getExperienceStage(player:getLevel())*1*100) -- ALL players low stamina + Store boost
 	elseif staminaMinutes <= 840 then
-		player:setBaseXpGain(Game.getExperienceStage(player:getLevel())*0.5) -- 50 = 0.5x	all players
+		player:setBaseXpGain(Game.getExperienceStage(player:getLevel())*0.5*100) -- ALL players low stamina
 	end
 
 	if player:getClient().version > 1110 then


### PR DESCRIPTION
This pull request sets the correct XP Gain Rate value in the client when you log in. Previously it was displaying the multiplier not the %.